### PR TITLE
feat: name -> nickname으로 수정 후 제약조건에 따른 중복 체크 로직 작성 완료, handleLogin() -> loadForTokenIssue() 로 수정 완료

### DIFF
--- a/src/main/java/org/example/playground/domain/user/controller/AdminUserController.java
+++ b/src/main/java/org/example/playground/domain/user/controller/AdminUserController.java
@@ -3,13 +3,11 @@ package org.example.playground.domain.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.playground.domain.user.dto.ForAdminDTO;
 import org.example.playground.domain.user.dto.UserMyPageResponseDTO;
-import org.example.playground.domain.user.dto.UserSummaryDTO;
 import org.example.playground.domain.user.service.AdminUserService;
 import org.example.playground.domain.user.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/org/example/playground/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/playground/domain/user/controller/UserController.java
@@ -22,8 +22,7 @@ public class UserController {
     //회원 가입
     @PostMapping
     public ResponseEntity<UserRegisterResponseDTO> createUser(
-            @Valid @RequestBody UserRegisterRequestDTO userDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @Valid @RequestBody UserRegisterRequestDTO userDTO
     ) {
 
         //TODO 인증/인가 관련 로직은 시큐리티에서 처리하는 것이 나을 것 같은..?
@@ -51,11 +50,11 @@ public class UserController {
     }
 
     //TODO GET /me/questions?page=0&size=20 (마이페이지 - 질문 목록)
-//    @GetMapping("/questions")
+//    @GetMapping("me/questions")
 
 
     //TODO GET /me/answers?page=0&size=20 (마이페이지 에서 내가 쓴 댓글 클릭시 - 댓글 목록)
-//    @GetMapping("/answers")
+//    @GetMapping("me/answers")
 
     //마이페이지에서 삭제
     @DeleteMapping("/me")

--- a/src/main/java/org/example/playground/domain/user/dto/ForAdminDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/ForAdminDTO.java
@@ -15,7 +15,7 @@ public class ForAdminDTO {
     //관리자가 보기 편한 정보만 모은 dto
     private Long id;
     private String loginId;
-    private String name;
+    private String nickname;
     private String provider;
     private LocalDateTime joinedDate;
 
@@ -23,7 +23,7 @@ public class ForAdminDTO {
         return ForAdminDTO.builder()
                 .id(user.getId())
                 .loginId(user.getLoginId())
-                .name(user.getName())
+                .nickname(user.getNickname())
                 .provider(user.getProvider())
                 .joinedDate(user.getJoinedDate())
                 .build();

--- a/src/main/java/org/example/playground/domain/user/dto/OAuth2UserInfo.java
+++ b/src/main/java/org/example/playground/domain/user/dto/OAuth2UserInfo.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @Getter
 //successHandler에서 받아올 정보를 담는 그릇
 public class OAuth2UserInfo {
-    private String name;
-    private String email;
+    private String email;// null 허용, db에는 nullable = false
     private String provider;
     private String providerId;
 }

--- a/src/main/java/org/example/playground/domain/user/dto/UserMyPageResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/UserMyPageResponseDTO.java
@@ -13,13 +13,13 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 //마이페이지 용 자세한 정보 조회
 public class UserMyPageResponseDTO {
-    private String name;
+    private String nickname;
     private String email;
     private LocalDateTime joinedDate;
 
     public static UserMyPageResponseDTO userMyPageDTOFromEntity(User user){
         return UserMyPageResponseDTO.builder()
-                .name(user.getName())
+                .nickname(user.getNickname())
                 .email(user.getEmail())
                 .joinedDate(user.getJoinedDate())
                 .build();

--- a/src/main/java/org/example/playground/domain/user/dto/UserPostAnswerResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/UserPostAnswerResponseDTO.java
@@ -10,15 +10,12 @@ import org.example.playground.domain.user.entity.User;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PRIVATE)
 //유저 요약 보기 (게시글, 댓글 에 나오는 정보)
-//관리자의 유저 모아보기
-public class UserSummaryDTO {
-    private Long id;
-    private String name;
+public class UserPostAnswerResponseDTO {
+    private String nickname;
 
-    public static UserSummaryDTO userSummaryDTOFromEntity(User user){
-        return UserSummaryDTO.builder()
-                .id(user.getId())
-                .name(user.getName())
+    public static UserPostAnswerResponseDTO userPostAnswerResponseDTOFromEntity(User user){
+        return UserPostAnswerResponseDTO.builder()
+                .nickname(user.getNickname())
                 .build();
     }
 }

--- a/src/main/java/org/example/playground/domain/user/dto/UserRegisterRequestDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/UserRegisterRequestDTO.java
@@ -14,12 +14,6 @@ import lombok.Getter;
 @Builder(access = AccessLevel.PRIVATE)
 //회원가입 할때 받아오는 정보를 담는 DTO
 public class UserRegisterRequestDTO {
-    @Size(min = 10, max = 100)
-    @Pattern(
-            regexp = "^[가-힣a-zA-Z0-9]+$",
-            message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다."
-    )
-    private String name;
     @NotBlank
     @Size(max = 100)
     @Pattern( // 특수문자 사용 불가

--- a/src/main/java/org/example/playground/domain/user/dto/UserRegisterResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/UserRegisterResponseDTO.java
@@ -12,7 +12,8 @@ import java.util.stream.Collectors;
 @Builder(access = AccessLevel.PRIVATE)
 //회원가입 성공했을때 결과 출력용
 public class UserRegisterResponseDTO {
-    private String name;
+    private String nickname;
+    private String tag;
     private String loginId;
     private String email;
     private LocalDateTime joinedDate;
@@ -20,7 +21,7 @@ public class UserRegisterResponseDTO {
 
     public static UserRegisterResponseDTO userRegisterResponseDTOfromEntity(User user){
         return UserRegisterResponseDTO.builder()
-                .name(user.getName())
+                .nickname(user.getNickname())
                 .loginId(user.getLoginId())
                 .email(user.getEmail())
                 .joinedDate(user.getJoinedDate())

--- a/src/main/java/org/example/playground/domain/user/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/org/example/playground/domain/user/dto/UserUpdateRequestDTO.java
@@ -19,7 +19,7 @@ public class UserUpdateRequestDTO {
             regexp = "^[가-힣a-zA-Z0-9]+$",
             message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다."
     )
-    private String name;
+    private String nickname;
     @NotBlank
     @Size(max = 100)
     @Email

--- a/src/main/java/org/example/playground/domain/user/entity/User.java
+++ b/src/main/java/org/example/playground/domain/user/entity/User.java
@@ -5,12 +5,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.playground.domain.user.dto.OAuth2UserInfo;
 import org.example.playground.domain.user.dto.UserRegisterRequestDTO;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,20 +17,24 @@ import java.util.UUID;
 @Builder
 @Table(
         name = "users",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_provider_providerId", columnNames = {"provider", "provider_id"}),
+                @UniqueConstraint(name= "uk_user_login_id", columnNames = {"login_id"}),
+                @UniqueConstraint(name = "uk_user_nickname", columnNames = {"nickname"})
+        }
 )
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", nullable = false, length = 100)
-    private String name; // 닉네임
+    @Column(name = "nickname", nullable = false, length = 100)
+    private String nickname; // 닉네임
 
-    @Column(name = "login_id", nullable = false, unique = true, length = 100)
+    @Column(name = "login_id", nullable = false)
     private String loginId;
 
-    @Column(name = "password", nullable = false, length = 100)
+    @Column(name = "password", nullable = false)
     private String password;
 
     @Column(name = "email", length = 100)
@@ -42,9 +44,9 @@ public class User {
     private LocalDateTime joinedDate;
 
     //소셜 로그인 관련 필드
-    @Column(name = "provider", length = 100)
+    @Column(name = "provider")
     private String provider; // 소셜 로그인 제공자 (없으면 일반 회원)
-    @Column(name = "provider_id", length = 100)
+    @Column(name = "provider_id")
     private String providerId; // 소셜 계정과 연결될 때 쓰는 ID
 
     @Builder.Default
@@ -60,25 +62,21 @@ public class User {
         }
     }
 
-    public static User userFromDTO(UserRegisterRequestDTO userDTO, String encodingPW){
+    public static User createLocalUser(UserRegisterRequestDTO userDTO, String nickname, String encodingPW){
         return User.builder()
-                .name(userDTO.getName())
+                .nickname(nickname)
                 .loginId(userDTO.getLoginId())
                 .password(encodingPW)
                 .email(userDTO.getEmail())
                 .build();
     }
 
-    public static User userFromOAuthUser(OAuth2UserInfo info, PasswordEncoder passwordEncoder) {
-        String loginId = info.getProvider() + "_" + info.getProviderId();
-
-        // 소셜 유저는 password 로그인에 쓰지 않으므로 더미 생성 (NOT NULL 만족용)
-        String dummyPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+    public static User createOAuthUser(OAuth2UserInfo info,String loginId, String nickname, String encodingPW) {
 
         return User.builder()
-                .name(info.getName() != null ? "("+ info.getProvider() +")" + info.getName() : info.getProvider() + "_user")
+                .nickname(nickname)
                 .loginId(loginId)
-                .password(dummyPassword)
+                .password(encodingPW)
                 .email(info.getEmail())
                 .provider(info.getProvider())
                 .providerId(info.getProviderId())
@@ -97,8 +95,8 @@ public class User {
         roles.add(userRole);
     }
 
-    public void changeName(String name) {
-        this.name = name;
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
     }
 
     public void changeEmail(String email) {

--- a/src/main/java/org/example/playground/domain/user/service/UserFactory.java
+++ b/src/main/java/org/example/playground/domain/user/service/UserFactory.java
@@ -1,0 +1,50 @@
+package org.example.playground.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.playground.domain.user.dto.OAuth2UserInfo;
+import org.example.playground.domain.user.dto.UserRegisterRequestDTO;
+import org.example.playground.domain.user.entity.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+@RequiredArgsConstructor
+public class UserFactory {
+    private final PasswordEncoder passwordEncoder;
+
+    // 유니크 name 자동 생성 (짧고 충돌확률 낮게)
+    private static final int NAME_LEN = 10;
+    private static final String NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    public User createLocal(UserRegisterRequestDTO dto, String nickname) {
+        return User.createLocalUser(
+                dto,
+                nickname,
+                passwordEncoder.encode(dto.getPassword())
+        );
+    }
+
+    public User createOAuth(OAuth2UserInfo info, String nickname) {
+        // 소셜 유저는 password 로그인에 쓰지 않으므로 더미 생성 (NOT NULL 만족용)
+        String dummyPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        String loginId = info.getProvider() + ":" + info.getProviderId();
+
+        return User.createOAuthUser(
+                info,
+                loginId,
+                nickname,
+                dummyPassword);
+    }
+
+    public String newAutoNickname() {
+        StringBuilder sb = new StringBuilder("익명의 개발자_");
+        for (int i = 0; i < NAME_LEN; i++) {
+            int idx = ThreadLocalRandom.current().nextInt(NAME_CHARS.length());
+            sb.append(NAME_CHARS.charAt(idx));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/example/playground/domain/user/service/UserService.java
+++ b/src/main/java/org/example/playground/domain/user/service/UserService.java
@@ -8,7 +8,7 @@ public interface UserService {
     UserRegisterResponseDTO createUser(UserRegisterRequestDTO userDTO);
 
     //security 일반 로그인 용 메서드
-    SecurityResponseForJWT handleLogin(String loginId);
+    SecurityResponseForJWT loadForTokenIssue(String loginId);
 
     SecurityResponseForJWT handleOAuth2Login(OAuth2UserInfo oAuthUserInfo);
 

--- a/src/main/java/org/example/playground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/playground/domain/user/service/UserServiceImpl.java
@@ -3,7 +3,6 @@ package org.example.playground.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.playground.domain.user.dto.*;
-import org.example.playground.domain.user.entity.Role;
 import org.example.playground.domain.user.entity.User;
 import org.example.playground.domain.user.exception.DuplicateUserException;
 import org.example.playground.domain.user.exception.OAuth2SignedupException;
@@ -11,45 +10,59 @@ import org.example.playground.domain.user.exception.UserNotFoundException;
 import org.example.playground.domain.user.repository.RoleRepository;
 import org.example.playground.domain.user.repository.UserRepository;
 import org.example.playground.global.security.user.CustomUserDetails;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.example.playground.domain.user.dto.UserRegisterResponseDTO.userRegisterResponseDTOfromEntity;
-import static org.example.playground.domain.user.entity.User.userFromDTO;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+    private static final int NAME_RETRY = 5;
+    private static final String UK_NICKNAME = "uk_user_nickname";
+    private static final String UK_LOGIN_ID = "uk_user_login_id";
+    private static final String UK_PROVIDER = "uk_user_provider_providerId";
+
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final UserFactory userFactory;
 
     @Override
     @Transactional
     public UserRegisterResponseDTO createUser(UserRegisterRequestDTO userDTO) {
-        if (userRepository.existsByLoginId(userDTO.getLoginId())) {
-            throw new DuplicateUserException("이미 존재하는 로그인 ID입니다");
+        for (int attempt = 1; attempt <= NAME_RETRY; attempt++) {
+            User user = userFactory.createLocal(userDTO, userFactory.newAutoNickname());
+            try {
+                User saved = saveUserWithDefaultRole(user);
+                return userRegisterResponseDTOfromEntity(saved);
+            } catch (DataIntegrityViolationException e) {
+                // loginId는 사용자 입력 → 즉시 실패
+                if (isLoginIdDuplicate(e)) {
+                    throw new DuplicateUserException("이미 존재하는 로그인 ID입니다");
+                }
+
+                // nickname은 자동 생성 → 재시도
+                if (isNicknameDuplicate(e)) {
+                    log.debug("닉네임 충돌로 재시도합니다. attempt={}/{}", attempt, NAME_RETRY);
+                    continue;
+                }
+
+                // 기타 무결성 위반/DB 예외는 그대로 올림(운영 정책에 따라 도메인 예외로 감싸도 됨)
+                throw e;
+            }
         }
 
-        // 비밀번호 인코딩 과정
-        // DB에 넣을 인스턴스 가공
-        String encodingPW = passwordEncoder.encode(userDTO.getPassword());
-        User user = userFromDTO(userDTO, encodingPW);
-
-        addUserRole(user);
-
-        return userRegisterResponseDTOfromEntity(userRepository.save(user));
+        throw new IllegalStateException("이름 생성 충돌이 반복되어 회원가입에 실패했습니다. 잠시 후 다시 시도하세요.");
     }
 
-    //TODO 재현님쪽으로 가는 메서드
+    // TODO: 로그인 인증은 AuthenticationManager에서 처리. 이 메서드는 인증 성공 후 사용자 조회/토큰 클레임 생성용으로 사용
     @Override
-    public SecurityResponseForJWT handleLogin(String loginId) {
+    public SecurityResponseForJWT loadForTokenIssue(String loginId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UserNotFoundException("유저가 존재하지 않습니다"));
 
@@ -61,51 +74,17 @@ public class UserServiceImpl implements UserService {
     //OAuth2 인증을 성공한 유저가 회원이 아니라면 회원테이블에 추가하는 로직
     //반환타입은 토큰 발급에 필요한 두개의 필드를 가진 별도의 타입
     public SecurityResponseForJWT handleOAuth2Login(OAuth2UserInfo info) {
-        User user = findOAuth2User(info)
-                .orElseGet(() -> raceHandler(info));   // 가입
+        User user = findOrCreateOAuthUser(info);   // 가입
 
         // 여기서 로그인 처리 의미는 사용자 식별 완료
         return SecurityResponseForJWT.securityResponseFromUser(user);
-    }
-
-    //Race Condition check. 동일 provider/providerId로 동시 요청 시 유니크 충돌 복구
-    private User raceHandler(OAuth2UserInfo info) {
-        try {
-            return registerOAuth2User(info);
-        } catch (DataIntegrityViolationException e) {
-            //그 사이에 이미 회원등록이 된 경우
-            return findOAuth2User(info).orElseThrow(()
-                    -> {
-                //race condition 상황이 아닐때(ex> 제약위반)
-                log.warn("OAuth2 회원 추가 실패 그러나 DB에서 회원 발견되지 않음. provider={}, providerId={}", info.getProvider(), info.getProviderId(), e);
-                throw new OAuth2SignedupException("소셜 로그인 처리 중 오류가 발생했습니다");
-            });
-        }
-    }
-
-    //로그인한 유저인지 찾는 메서드
-    private Optional<User> findOAuth2User(OAuth2UserInfo info) {
-        return userRepository.findUserByProviderAndProviderId(info.getProvider(), info.getProviderId());
-    }
-
-    //회원테이블에 없다면 새로 등록하는 회원가입 메서드
-    private User registerOAuth2User(OAuth2UserInfo info) {
-        User user = User.userFromOAuthUser(info, passwordEncoder);
-        addUserRole(user);
-        return userRepository.save(user);
-    }
-
-    //기본적으로 USER 권한 부여. 만약 roles 테이블에 USER 이 없을 시 새로 만들어서 USER 부여. (첫 회원)
-    private void addUserRole(User user) {
-        user.addRole(roleRepository.findByName("ROLE_USER").orElseGet(()
-                -> roleRepository.save(new Role("ROLE_USER"))));
     }
 
     //회원 마이페이지용 유저 정보 조회 메서드
     @Override
     @Transactional(readOnly = true)
     public UserMyPageResponseDTO getUser(CustomUserDetails currentUser) {
-        User findUser = findUserFromDB(currentUser.getId());
+        User findUser = findUserOrThrow(currentUser.getId());
 
         return UserMyPageResponseDTO.userMyPageDTOFromEntity(findUser);
     }
@@ -114,13 +93,21 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UserMyPageResponseDTO updateUser(CustomUserDetails currentUser, UserUpdateRequestDTO userUpdateRequestDTO) {
-        User findUser = findUserFromDB(currentUser.getId());
+        User findUser = findUserOrThrow(currentUser.getId());
 
-        if (!findUser.getName().equals(userUpdateRequestDTO.getName())) {
-            findUser.changeName(userUpdateRequestDTO.getName());
+        if (!Objects.equals(findUser.getNickname(), userUpdateRequestDTO.getNickname())) {
+            findUser.changeNickname(userUpdateRequestDTO.getNickname());
+            try {
+                userRepository.flush();
+            } catch (DataIntegrityViolationException e) {
+                if (isNicknameDuplicate(e)) {
+                    throw new DuplicateUserException("이미 사용 중인 이름입니다");
+                }
+                throw e;
+            }
         }
 
-        if (!Objects.equals(findUser.getEmail(), userUpdateRequestDTO.getEmail())){
+        if (!Objects.equals(findUser.getEmail(), userUpdateRequestDTO.getEmail())) {
             findUser.changeEmail(userUpdateRequestDTO.getEmail());
         }
 
@@ -130,14 +117,104 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUser(CustomUserDetails currentUser) {
-        User findUser = findUserFromDB(currentUser.getId());
+        User findUser = findUserOrThrow(currentUser.getId());
         userRepository.delete(findUser);
     }
 
+    //가능하면 constraintName을 제공하는 Hibernate 예외를 우선 확인하고, 없으면 메시지 fallback을 사용한다
+    private boolean hasConstraint(Throwable e, String constraintName) {
+        Throwable t = e;
+
+        while (t != null) {
+
+            // 1. Hibernate ConstraintViolationException 우선 시도
+            // ConstraintViolationException → “DB의 어떤 규칙이 깨졌는지”를 아는 예외 ( null일 수 있음 )
+            if (t instanceof ConstraintViolationException cve) {
+                String violated = cve.getConstraintName();
+                if (constraintName.equals(violated)) {
+                    return true;
+                }
+            }
+
+            // 2️. fallback: 메시지 기반 파싱
+            // DataIntegrityViolationException → “데이터 무결성에 문제가 생겼다”라고 Spring이 포괄적으로 감싸서 던지는 예외
+            String msg = t.getMessage();
+            if (msg != null && msg.contains(constraintName)) {
+                return true;
+            }
+
+            t = t.getCause();
+        }
+
+        return false;
+    }
+
+    private boolean isNicknameDuplicate(Throwable e) {
+        return hasConstraint(e, UK_NICKNAME);
+    }
+
+    private boolean isLoginIdDuplicate(Throwable e) {
+        return hasConstraint(e, UK_LOGIN_ID);
+    }
+
+    private boolean isProviderDuplicate(Throwable e) {
+        return hasConstraint(e, UK_PROVIDER);
+    }
+
     // 회원정보 검색하는 메서드
-    private User findUserFromDB(Long id) {
+    private User findUserOrThrow(Long id) {
         return userRepository.findById(id).orElseThrow(() ->
                 new UserNotFoundException("존재하지 않는 회원입니다."));
+    }
+
+    //로그인한 유저인지 찾는 메서드
+    private User findOrCreateOAuthUser(OAuth2UserInfo info) {
+        return userRepository.findUserByProviderAndProviderId(info.getProvider(), info.getProviderId())
+                .orElseGet(() -> createOAuthUserWithRetry(info));
+    }
+
+    //Race Condition check. 동일 provider/providerId로 동시 요청 시 유니크 충돌 복구
+    private User createOAuthUserWithRetry(OAuth2UserInfo info) {
+        for (int attempt = 1; attempt <= NAME_RETRY; attempt++) {
+            User user = userFactory.createOAuth(info, userFactory.newAutoNickname());
+            try {
+                return saveUserWithDefaultRole(user);
+            } catch (DataIntegrityViolationException e) {
+                // provider/providerId 유니크 충돌: 다른 요청이 먼저 가입했을 확률 ↑ → 재조회로 회수
+                if (isProviderDuplicate(e)) {
+                    return userRepository.findUserByProviderAndProviderId(info.getProvider(), info.getProviderId())
+                            .orElseThrow(() -> e);
+                }
+
+                // nickname 유니크 충돌: 닉네임만 바꿔 재시도
+                if (isNicknameDuplicate(e)) {
+                    log.debug("OAuth 닉네임 충돌로 재시도합니다. attempt={}/{}", attempt, NAME_RETRY);
+                    continue;
+                }
+
+                // loginId(= provider:providerId) 유니크 충돌이 난다면 설계상 provider 충돌과 동치에 가까움.
+                // 그래도 혹시 모르니 방어적으로 provider 재조회 시도 후 실패면 예외 전파
+                if (isLoginIdDuplicate(e)) {
+                    return userRepository.findUserByProviderAndProviderId(info.getProvider(), info.getProviderId())
+                            .orElseThrow(() -> e);
+                }
+
+                throw e;
+            }
+        }
+        throw new OAuth2SignedupException("소셜 로그인 처리 중 오류가 발생했습니다");
+    }
+
+    // 기본 ROLE_USER를 부여한 뒤 저장(즉시 flush하여 유니크 위반을 현재 스코프에서 감지)
+    private User saveUserWithDefaultRole(User user) {
+        addUserRole(user);
+        return userRepository.saveAndFlush(user);
+    }
+
+    //기본적으로 USER 권한 부여
+    private void addUserRole(User user) {
+        user.addRole(roleRepository.findByName("ROLE_USER").orElseThrow(()
+                -> new IllegalStateException("ROLE_USER가 존재하지 않습니다. DB 초기화 상태를 확인하세요.")));
     }
 }
 

--- a/src/main/java/org/example/playground/domain/user/service/serviceStudy.md
+++ b/src/main/java/org/example/playground/domain/user/service/serviceStudy.md
@@ -1,0 +1,95 @@
+## 왜 `t = e;`로 시작해서 `t = t.getCause();`로 내려가나?
+
+### 1. 핵심 결론
+Spring/JPA 환경에서 **DB 예외는 여러 계층으로 감싸져(wrapping) 전달**된다.  
+따라서 **겉 예외만 보면 원인을 알 수 없고**,  
+`getCause()`를 따라 **안쪽(진짜 원인)까지 내려가며 검사해야 한다.**
+
+---
+
+### 2. 예외가 “겹겹이 포장되는” 이유
+
+Spring은 DB, JPA, JDBC, 드라이버 등 **서로 다른 기술 계층의 예외를 통일된 형태로 감싸서** 던진다.
+
+이를 **예외 래핑(Exception Wrapping)** 이라고 한다.
+
+---
+
+### 3. 현실적인 예외 체인 구조 예시
+
+```text
+DataIntegrityViolationException  ← Spring
+└─ cause: ConstraintViolationException  ← Hibernate
+   └─ cause: SQLIntegrityConstraintViolationException  ← JDBC
+      └─ cause: MysqlDataTruncation / SQLStateException  ← DB Driver
+```
+```
+private boolean isNicknameDuplicate(Throwable e) {
+    return hasConstraint(e, UK_NICKNAME);
+}
+
+private boolean hasConstraint(Throwable e, String constraint) {
+    Throwable t = e;
+    while (t != null) {
+        String msg = t.getMessage();
+        if (msg != null && msg.contains(constraint)) {
+            return true;
+        }
+        t = t.getCause();
+    }
+    return false;
+}
+
+```
+
+=====================================================================
+
+**ConstraintViolationException** 은
+→ “DB의 어떤 규칙이 깨졌는지”를 정확히 아는 예외이고
+
+**DataIntegrityViolationException** 은
+→ “데이터 무결성에 문제가 생겼다”라고 Spring이 포괄적으로 감싸서 던지는 예외야.
+
+둘은 경쟁 관계가 아니라, **포장 관계**야.
+
+```
+메시지 기반은 “개발환경에서는 잘 되는데 운영에서 제약명 못 찾는” 상황이 실제로 자주 나옵니다.
+
+DB가 바뀌거나(H2 → MySQL)
+
+드라이버 버전이 바뀌거나
+
+메시지 로케일이 바뀌면
+contains("uk_user_nickname")가 실패할 수 있습니다.
+```
+
+ConstraintViolationException 기반은 이런 문제를 크게 줄입니다.
+
+### ConstraintViolationException을 직접 catch하지 않는다.
+
+왜냐면:
+
+- Hibernate에 종속되기 때문
+
+- Spring의 추상화 계층을 깨기 때문
+
+대신 이렇게 한다.
+
+#### catch는 DataIntegrityViolationException으로 한다
+(Spring이 보장하는 안정적인 인터페이스)
+
+- 내부 원인을 살펴본다
+
+- 원인 중에 ConstraintViolationException이 있는지 확인
+
+- 있으면 거기서 제약 이름을 꺼내 쓴다
+
+```
+“DB 유니크 제약을 최종 판단 기준으로 삼았고,
+Hibernate의 ConstraintViolationException에서 제공하는
+constraintName을 1차로 사용합니다.
+
+다만 환경 차이로 해당 정보가 없는 경우를 대비해
+메시지 기반 파싱을 fallback으로 두어
+운영 안정성을 확보했습니다.”
+```


### PR DESCRIPTION
### 작업 내용
- 전반적인 코드 리펙토링 완료
- 변수명 일부 수정
- 메서드명 일부 수정 ( CustomUserDetailsService 에서 사용하는 메서드 명 변경 해야함 )
- service 부분 공부한 내용 md 파일로 작성 후 service 디렉에 업데이트 완료

### 비즈니스 로직 변경 사항
- 사용자는 nickname으로 서로를 식별한다 (제약 조건 위반 메세지에서 정확한 구분을 위해 name 이 아닌 nickname을 사용)
- 사용자는 회원가입시에 본인의 nickname을 정하지 않고 서버가 알아서 정해준다. 추후에 본인이 원하면 변경 가능하다
- 소셜 회원의 loginId 형식을 provider_providerId에서 provider:providerId 으로 수정한다. (providerId에 _가 포함되는 경우가 있어서 가독성을 위해 변경