### PR TITLE
fix: name -> nickname으로 필드이름 변경

### DIFF
--- a/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
+++ b/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
@@ -41,19 +41,6 @@ public class QuestionController {
         return questionService.search(type, keyword, pageable);
     }
 
-    // 마이페이지에 필요한 api는 민섭님이, 나는 필요가 없다
-   // 마이페이지에서 내가 작성한 질문 목록 조회
-    /*
-    @GetMapping("/me")
-    public Page<QuestionSummaryResponseDTO> myQuestions(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            Pageable pageable
-    ) {
-        return questionService.getMyQuestions(principal.getId(), pageable)
-    }
-
-     */
-
 
 
     //질문 상세 조회(1건) //responseBody로 json으로 변환 - 프론트에 넘겨줌,

--- a/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 public record QuestionDetailResponseDTO(
         Long id,
-        String name,
+        String nickname,
         String title,
         String content,
         LocalDateTime createdAt,
@@ -15,7 +15,7 @@ public record QuestionDetailResponseDTO(
     public static QuestionDetailResponseDTO from(Question question) {
         return new QuestionDetailResponseDTO(
                 question.getId(),
-                question.getUser().getName(),
+                question.getUser().getNickname(),
                 question.getTitle(),
                 question.getContent(),
                 question.getCreatedAt(),

--- a/src/main/java/org/example/playground/domain/question/dto/response/QuestionSummaryResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/question/dto/response/QuestionSummaryResponseDTO.java
@@ -7,14 +7,14 @@ import java.util.Locale;
 
 public record QuestionSummaryResponseDTO(
         Long id,
-        String name, //닉네임
+        String nickname, //닉네임
         String title,
         LocalDateTime createdAt
 ) {
     public static QuestionSummaryResponseDTO from(Question question) {
         return new QuestionSummaryResponseDTO(
                 question.getId(),
-                question.getUser().getName(),
+                question.getUser().getNickname(),
                 question.getTitle(),
                 question.getCreatedAt()
 


### PR DESCRIPTION
## 변경 내용
- QuestionDetailResponseDTO, QuestionSummaryResponseDTO에서
  작성자 필드를 name -> nickname 으로 변경
- DTO 변환 로직에서 question.getUser().getName() 대신
  question.getUser().getNickname() 사용하도록 수정

## 변경 이유
- User 도메인 정책과 일관되게 하려고