### PR TITLE
feat: 포인트 도메인 관련 필드 User 엔티티에 추가, 소프트삭제 구현 완료, 회원 탈퇴시 로그인 불가 로직 구현 완료, 질문 답변 댓글와 User간의 관계 단방향으로 결정

### DIFF
--- a/src/main/java/org/example/playground/domain/user/entity/User.java
+++ b/src/main/java/org/example/playground/domain/user/entity/User.java
@@ -49,8 +49,8 @@ public class User {
     @Column(name = "joined_date", updatable = false)
     private LocalDateTime joinedDate;
 
-    @Column(name = "current_points")
-    private int point;
+    @Column(name = "current_points", nullable = false)
+    private long currentPoints = 0L;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -130,9 +130,5 @@ public class User {
 
     public void changeEmail(String email) {
         this.email = email;
-    }
-
-    public void changePoints(int value) {
-        this.point += value;
     }
 }

--- a/src/main/java/org/example/playground/domain/user/entity/User.java
+++ b/src/main/java/org/example/playground/domain/user/entity/User.java
@@ -3,11 +3,16 @@ package org.example.playground.domain.user.entity;
 import jakarta.persistence.*;
 
 import lombok.*;
+import org.example.playground.domain.answer.entity.Answer;
+import org.example.playground.domain.question.entity.Question;
 import org.example.playground.domain.user.dto.OAuth2UserInfo;
 import org.example.playground.domain.user.dto.UserRegisterRequestDTO;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +28,7 @@ import java.util.Set;
                 @UniqueConstraint(name = "uk_user_nickname", columnNames = {"nickname"})
         }
 )
+@SQLDelete(sql = "UPDATE users SET status='DELETED', deleted_at=now() WHERE id=?") // userRepository.delete시 update가 나감.
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,6 +48,29 @@ public class User {
 
     @Column(name = "joined_date", updatable = false)
     private LocalDateTime joinedDate;
+
+    @Column(name = "current_points")
+    private int point;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return status == UserStatus.DELETED;
+    }
+    //소프트 삭제 후 로그인 불가능!
+    public void softDeleteAndAnonymize() {
+        this.status = UserStatus.DELETED;
+        this.deletedAt = LocalDateTime.now();
+
+        this.nickname = "deleted#" + this.nickname;
+        this.loginId = "deleted_" + this.id; // 재로그인 방지
+        this.email = null;
+        this.providerId = "deleted_" + this.providerId; // 재로그인 방지
+    }
 
     //소셜 로그인 관련 필드
     @Column(name = "provider")
@@ -101,5 +130,9 @@ public class User {
 
     public void changeEmail(String email) {
         this.email = email;
+    }
+
+    public void changePoints(int value) {
+        this.point += value;
     }
 }

--- a/src/main/java/org/example/playground/domain/user/entity/UserStatus.java
+++ b/src/main/java/org/example/playground/domain/user/entity/UserStatus.java
@@ -1,0 +1,5 @@
+package org.example.playground.domain.user.entity;
+
+public enum UserStatus {
+    ACTIVE, DELETED
+}

--- a/src/main/java/org/example/playground/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/playground/domain/user/repository/UserRepository.java
@@ -1,13 +1,13 @@
 package org.example.playground.domain.user.repository;
 
 import org.example.playground.domain.user.entity.User;
-import org.example.playground.domain.user.entity.UserRole;
 import org.example.playground.domain.user.entity.UserStatus;
-import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
-import java.util.Set;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     //회원 DB에 등록되어있는지 확인용
@@ -20,6 +20,27 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     //로그인 아이디로 회원 검색(회원정보 상세조회)
     Optional<User> findByLoginId(String loginId);
-
     Optional<User> findByLoginIdAndStatus(String loginId, UserStatus status);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("""
+        update User u
+           set u.currentPoints = u.currentPoints + :amount
+         where u.id = :userId
+           and u.status = :active
+    """)
+    int increasePoints(@Param("userId") Long userId,
+                       @Param("amount") long amount,
+                       @Param("active") UserStatus active);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("""
+        update User u
+           set u.currentPoints = u.currentPoints - :amount
+         where u.id = :userId
+           and u.status = :active
+    """)
+    int decreasePoints(@Param("userId") Long userId,
+                       @Param("amount") long amount,
+                       @Param("active") UserStatus active);
 }

--- a/src/main/java/org/example/playground/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/playground/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package org.example.playground.domain.user.repository;
 
 import org.example.playground.domain.user.entity.User;
 import org.example.playground.domain.user.entity.UserRole;
+import org.example.playground.domain.user.entity.UserStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,10 +13,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     //회원 DB에 등록되어있는지 확인용
     boolean existsByLoginId(String loginId);
     boolean existsByProviderAndProviderId(String provider,String providerId);
+    boolean existsByIdAndStatus(Long id, UserStatus status);
 
     //OAuth2 로그인 회원만 검색
     Optional<User> findUserByProviderAndProviderId(String provider, String providerId);
 
     //로그인 아이디로 회원 검색(회원정보 상세조회)
     Optional<User> findByLoginId(String loginId);
+
+    Optional<User> findByLoginIdAndStatus(String loginId, UserStatus status);
 }

--- a/src/main/java/org/example/playground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/playground/domain/user/service/UserServiceImpl.java
@@ -108,7 +108,11 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User findUser = findUserOrThrow(userId);
-        userRepository.delete(findUser);
+
+//        refreshTokenRepository.deleteByUserId(userId);
+
+        findUser.softDeleteAndAnonymize();
+        userRepository.save(findUser);
     }
 
     //가능하면 constraintName을 제공하는 Hibernate 예외를 우선 확인하고, 없으면 메시지 fallback을 사용한다
@@ -160,6 +164,12 @@ public class UserServiceImpl implements UserService {
     //로그인한 유저인지 찾는 메서드
     private User findOrCreateOAuthUser(OAuth2UserInfo info) {
         return userRepository.findUserByProviderAndProviderId(info.getProvider(), info.getProviderId())
+                .map(found -> {
+                    if (found.isDeleted()) {
+                        throw new OAuth2SignedupException("탈퇴한 계정입니다.");
+                    }
+                    return found;
+                })
                 .orElseGet(() -> createOAuthUserWithRetry(info));
     }
 


### PR DESCRIPTION
### 작업 내용
- 포인트 도메인과 관련된 필드 , 메서드 User 엔티티에 추가 
-> 최종 포인트로 활동 로그는 포인트 도메인에서 관리.  포인트 도메인에서 UserRepository에 선언된 메서드 사용 예정.
-> 포인트는 차감되어서 음수로도 떨어질 수 있도록 구현함.

- 소프트 삭제 구현 완료, User 엔티티에 관련 필드 추가 완료 (탈퇴시에 사용자의 모든 정보를 숨기는 메서드도 추가 완료)
-> 로그인 시 탈퇴한 사용자인지 확인 절차 추가 요청할 계획
---

### 요청 사항
-  @kimjaehyun7 
-> login 메서드에
```
User user = userRepository.findByLoginIdAndStatus(loginRequestDTO.getLoginId(), UserStatus.ACTIVE)
            .orElseThrow(() -> new LoginFailedException("아이디 또는 비밀번호가 틀렸습니다."));
// (2중 방어) 혹시 모를 상태 체크
    if (user.isDeleted()) {
        throw new LoginFailedException("아이디 또는 비밀번호가 틀렸습니다.");
    }
```
-> tokenToAuthentication 메서드에
```
// 탈퇴 유저면 즉시 차단
    boolean active = userRepository.existsByIdAndStatus(userId, UserStatus.ACTIVE);
    if (!active) {
        throw new BadCredentialsException("DELETED_USER"); // 401로 떨어지게
    }
```
-> 리프레쉬 토큰 삭제 메서드도 필요함.
```
refreshTokenRepository.deleteByUserId(userId);
```
- @kkhw1000 
-> PointService 에서 포인트 변동 로직에 UserStatus 확인 로직 추가 요청
```
if (user.getStatus() != UserStatus.ACTIVE) {
            throw new DeletedUserPointOperationException("탈퇴/비활성 사용자 포인트 변경 불가");
        }
```

