### PR TITLE
feat: 질문 상세 조회수 증가 및 답변 채택 정책 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 ## test용 yml
 application-test.yml
+application-local.yml
 
 ## test용 sql
 src/main/resources/*.sql

--- a/src/main/java/org/example/playground/domain/answer/controller/AnswerController.java
+++ b/src/main/java/org/example/playground/domain/answer/controller/AnswerController.java
@@ -71,16 +71,11 @@ public class AnswerController {
         //TODO 신고 정책 확정 후 구현
     }
 
-    //답변 채택
-    @PatchMapping("/questions/{questionId}/answers/{answerId}/accept")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void accept(
-            @PathVariable Long questionId,
-            @PathVariable Long answerId,
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
-        //TODO 질문 작성자만 채택 가능하도록 권한체크 후 구현
-    }
+
+
+
+
+
 
 
 }

--- a/src/main/java/org/example/playground/domain/answer/dto/response/AnswerSummaryResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/answer/dto/response/AnswerSummaryResponseDTO.java
@@ -8,6 +8,7 @@ public record AnswerSummaryResponseDTO(
         Long id,
         String nickname,
         String content,
+        boolean accepted,
         LocalDateTime createdAt
 ) {
 
@@ -16,6 +17,7 @@ public record AnswerSummaryResponseDTO(
                 answer.getId(),
                 answer.getUser().getNickname(),
                 answer.getContent(),
+                answer.isAccepted(),
                 answer.getCreatedAt()
         );
     }

--- a/src/main/java/org/example/playground/domain/answer/entity/Answer.java
+++ b/src/main/java/org/example/playground/domain/answer/entity/Answer.java
@@ -69,10 +69,6 @@ public class Answer {
     }
 
     
-    //답변 채택 해제
-    public void unaccept() {
-        this.accepted = false;
-    }
 
 }
 

--- a/src/main/java/org/example/playground/domain/answer/entity/Answer.java
+++ b/src/main/java/org/example/playground/domain/answer/entity/Answer.java
@@ -39,6 +39,10 @@ public class Answer {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    //채택여부
+    @Column(nullable = false)
+    private boolean accepted;
+
     // 답변 생성
     public static Answer create(Question question, User user, String content) {
         LocalDateTime now = LocalDateTime.now();
@@ -58,5 +62,17 @@ public class Answer {
         }
         this.updatedAt = LocalDateTime.now();
     }
+
+    //답변 채택
+    public void accept() {
+        this.accepted = true;
+    }
+
+    
+    //답변 채택 해제
+    public void unaccept() {
+        this.accepted = false;
+    }
+
 }
 

--- a/src/main/java/org/example/playground/domain/answer/exception/AnswerNotInQuestionException.java
+++ b/src/main/java/org/example/playground/domain/answer/exception/AnswerNotInQuestionException.java
@@ -1,0 +1,7 @@
+package org.example.playground.domain.answer.exception;
+
+public class AnswerNotInQuestionException extends RuntimeException {
+    public AnswerNotInQuestionException() {
+        super("해당 질문에 달린 답변만 채택할 수 있습니다.");
+    }
+}

--- a/src/main/java/org/example/playground/domain/answer/exception/CannotAnswerOwnQuestionException.java
+++ b/src/main/java/org/example/playground/domain/answer/exception/CannotAnswerOwnQuestionException.java
@@ -1,0 +1,7 @@
+package org.example.playground.domain.answer.exception;
+
+public class CannotAnswerOwnQuestionException extends RuntimeException {
+    public CannotAnswerOwnQuestionException() {
+        super("자기 질문에는 답변을 작성할 수 없습니다.");
+    }
+}

--- a/src/main/java/org/example/playground/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/org/example/playground/domain/answer/repository/AnswerRepository.java
@@ -1,16 +1,29 @@
 package org.example.playground.domain.answer.repository;
 
-import lombok.RequiredArgsConstructor;
 import org.example.playground.domain.answer.entity.Answer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AnswerRepository extends JpaRepository<Answer,Long> {
+import java.util.List;
 
-    //해당 질문의 답변 목록 - 최신순
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    // 해당 질문의 답변 목록 - 최신순
     Page<Answer> findByQuestion_IdOrderByCreatedAtDesc(Long questionId, Pageable pageable);
 
-    //마이페이지 내가 작성한 답변 목록 조회용 - 최신순
+    // 마이페이지 내가 작성한 답변 목록 조회용 - 최신순
     Page<Answer> findByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // 질문에 달린 답변 목록 조회 (정렬 없음)
+    List<Answer> findByQuestion_Id(Long questionId);
+
+    //중복 채택 방지: 해당 질문에 accepted=true 답변 존재 여부
+    boolean existsByQuestion_IdAndAcceptedTrue(Long questionId);
+
+    //정렬: 채택된 답변 우선 + 최신순
+    List<Answer> findByQuestion_IdOrderByAcceptedDescCreatedAtDesc(Long questionId);
+
+    Page<Answer> findByQuestion_IdOrderByAcceptedDescCreatedAtDesc(Long questionId, Pageable pageable);
+
 }

--- a/src/main/java/org/example/playground/domain/answer/service/AnswerService.java
+++ b/src/main/java/org/example/playground/domain/answer/service/AnswerService.java
@@ -7,6 +7,7 @@ import org.example.playground.domain.answer.dto.response.AnswerDetailResponseDTO
 import org.example.playground.domain.answer.dto.response.AnswerSummaryResponseDTO;
 import org.example.playground.domain.answer.entity.Answer;
 import org.example.playground.domain.answer.exception.AnswerNotFoundException;
+import org.example.playground.domain.answer.exception.CannotAnswerOwnQuestionException;
 import org.example.playground.domain.answer.repository.AnswerRepository;
 import org.example.playground.domain.question.entity.Question;
 import org.example.playground.domain.question.exception.QuestionNotFoundException;
@@ -36,6 +37,12 @@ public class AnswerService {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
+        //자기 질문에 답변 달기 금지
+        Long questionOwnerId = question.getUser().getId();
+        if (userId.equals(question.getUser().getId())) {
+            throw new CannotAnswerOwnQuestionException();
+        }
+
         Answer answer = Answer.create(question, user, request.content());
         Answer saved = answerRepository.save(answer);
 
@@ -48,8 +55,11 @@ public class AnswerService {
     //해당 질문 답변 조회 - 전체
     @Transactional(readOnly = true)
     public Page<AnswerSummaryResponseDTO> getAnswerByQuestion(Long questionId, Pageable pageable){
-        return answerRepository.findByQuestion_IdOrderByCreatedAtDesc(questionId, pageable).map(AnswerSummaryResponseDTO::from);
+        return answerRepository
+                .findByQuestion_IdOrderByAcceptedDescCreatedAtDesc(questionId, pageable)
+                .map(AnswerSummaryResponseDTO::from);
     }
+
 
 
     //답변 수정 - 작성자만

--- a/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
+++ b/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
@@ -76,10 +76,11 @@ public class QuestionController {
     //질문 신고
     @PatchMapping("/{id}/report")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void report(@PathVariable Long id) {
-        //todo 질문 신고정책 설계 필요, 보통 관리자에게 알림 -> 지피티한테 관라자에게만 일림이 가는 코드를?
-        //민섭님에게 관리자 api, 거기서 쓸수있으면 좋음
-        //관리자 api한테 알림을 날려야돼! 라는 코드
+    public void report(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        questionService.report(id, principal.getId());
     }
     
     //질문에 답변 등록 알림 - 답변 도메인에서 "답변이 달렸다!" 이벤트를 만들고 여기에(이용자에게) 알림을 보냄 (AnswerService에서)

--- a/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
+++ b/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
@@ -84,4 +84,17 @@ public class QuestionController {
     }
     
     //질문에 답변 등록 알림 - 답변 도메인에서 "답변이 달렸다!" 이벤트를 만들고 여기에(이용자에게) 알림을 보냄 (AnswerService에서)
+
+
+    @PatchMapping("/questions/{questionId}/answers/{answerId}/accept")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void accept(
+            @PathVariable Long questionId,
+            @PathVariable Long answerId,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        questionService.acceptAnswer(questionId, answerId, principal.getId());
+    }
+
+
 }

--- a/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
+++ b/src/main/java/org/example/playground/domain/question/controller/QuestionController.java
@@ -27,12 +27,8 @@ public class QuestionController {
     public QuestionDetailResponseDTO create(
             @AuthenticationPrincipal CustomUserDetails principal,
             @Valid @RequestBody QuestionCreateRequestDTO request) {
-        System.out.println("questioncontroller log");
         return questionService.create(principal.getId(), request);
     }
-
-
-
 
     //질문 검색 - keyword 없으면 전체조회, 있으면 title,content,all검색(서비스에서 처리)
     @GetMapping
@@ -59,7 +55,7 @@ public class QuestionController {
     public QuestionDetailResponseDTO update(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails principal,
-            @RequestBody QuestionUpdateRequestDTO request)
+            @Valid @RequestBody QuestionUpdateRequestDTO request)
     {
         return questionService.update(id, principal.getId(), request);
     }
@@ -86,7 +82,8 @@ public class QuestionController {
     //질문에 답변 등록 알림 - 답변 도메인에서 "답변이 달렸다!" 이벤트를 만들고 여기에(이용자에게) 알림을 보냄 (AnswerService에서)
 
 
-    @PatchMapping("/questions/{questionId}/answers/{answerId}/accept")
+    //답변 채택
+    @PatchMapping("/{questionId}/answers/{answerId}/accept")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void accept(
             @PathVariable Long questionId,

--- a/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
@@ -10,6 +10,7 @@ public record QuestionDetailResponseDTO(
         String title,
         String content,
         Long viewCount,
+        Long acceptedAnswerId,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -20,6 +21,7 @@ public record QuestionDetailResponseDTO(
                 question.getTitle(),
                 question.getContent(),
                 question.getViewCount(),
+                question.getAcceptedAnswerId(),
                 question.getCreatedAt(),
                 question.getUpdatedAt()
         );

--- a/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
@@ -1,8 +1,11 @@
 package org.example.playground.domain.question.dto.response;
 
+import org.example.playground.domain.answer.dto.response.AnswerSummaryResponseDTO;
+import org.example.playground.domain.answer.entity.Answer;
 import org.example.playground.domain.question.entity.Question;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record QuestionDetailResponseDTO(
         Long id,
@@ -10,10 +13,25 @@ public record QuestionDetailResponseDTO(
         String title,
         String content,
         Long viewCount,
-        Long acceptedAnswerId,
+        List<AnswerSummaryResponseDTO> answers,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
+    public static QuestionDetailResponseDTO from(Question question, List<Answer> answers) {
+        return new QuestionDetailResponseDTO(
+                question.getId(),
+                question.getUser().getNickname(),
+                question.getTitle(),
+                question.getContent(),
+                question.getViewCount(),
+                answers.stream()
+                        .map(AnswerSummaryResponseDTO::from)
+                        .toList(),
+                question.getCreatedAt(),
+                question.getUpdatedAt()
+        );
+    }
+
     public static QuestionDetailResponseDTO from(Question question) {
         return new QuestionDetailResponseDTO(
                 question.getId(),
@@ -21,9 +39,10 @@ public record QuestionDetailResponseDTO(
                 question.getTitle(),
                 question.getContent(),
                 question.getViewCount(),
-                question.getAcceptedAnswerId(),
+                List.of(), // 답변 없음
                 question.getCreatedAt(),
                 question.getUpdatedAt()
         );
     }
+
 }

--- a/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
+++ b/src/main/java/org/example/playground/domain/question/dto/response/QuestionDetailResponseDTO.java
@@ -9,6 +9,7 @@ public record QuestionDetailResponseDTO(
         String nickname,
         String title,
         String content,
+        Long viewCount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -18,6 +19,7 @@ public record QuestionDetailResponseDTO(
                 question.getUser().getNickname(),
                 question.getTitle(),
                 question.getContent(),
+                question.getViewCount(),
                 question.getCreatedAt(),
                 question.getUpdatedAt()
         );

--- a/src/main/java/org/example/playground/domain/question/entity/Question.java
+++ b/src/main/java/org/example/playground/domain/question/entity/Question.java
@@ -28,7 +28,7 @@ public class Question {
     private List<Answer> answers = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false, length = 255)
@@ -51,9 +51,9 @@ public class Question {
     //신고횟수, 관리자가 판단할때의 근거
     private int reportCount = 0;
 
-    // 채택된 답변 id (없으면 null)
-    @Column(name = "acceptedAnswerId")
-    private Long acceptedAnswerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accepted_answer_id")
+    private Answer acceptedAnswer;
 
     //엔티티 저장 전 기본값 보장
     //Builder 사용 시 null이 될 수 있는 필드(createdAt, updatedAt, viewCount)를
@@ -106,23 +106,28 @@ public class Question {
         this.reportCount++;
     }
 
-    public void acceptAnswer(Long answerId, Long requesterId, Long answerWriterId) {
-        //질문 작성자만
+    public void acceptAnswer(Answer answer, Long requesterId) {
+        // 질문 작성자만
         if (!this.user.getId().equals(requesterId)) {
             throw new RuntimeException("질문 작성자만 채택할 수 있습니다.");
         }
 
-        //한 질문당 1개
-        if (this.acceptedAnswerId != null) {
+        // 한 질문당 1개
+        if (this.acceptedAnswer != null) {
             throw new RuntimeException("이미 채택된 답변이 있습니다.");
         }
 
-        //자기 답변 채택 금지
-        if (requesterId.equals(answerWriterId)) {
+        // 자기 답변 채택 금지
+        if (answer.getUser().getId().equals(requesterId)) {
             throw new RuntimeException("자기 답변은 채택할 수 없습니다.");
         }
 
-        this.acceptedAnswerId = answerId;
+        // 이 질문에 달린 답변만 채택 가능
+        if (!answer.getQuestion().getId().equals(this.id)) {
+            throw new RuntimeException("해당 질문의 답변만 채택할 수 있습니다.");
+        }
+
+        this.acceptedAnswer = answer;
     }
 
 }

--- a/src/main/java/org/example/playground/domain/question/entity/Question.java
+++ b/src/main/java/org/example/playground/domain/question/entity/Question.java
@@ -44,6 +44,30 @@ public class Question {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    //조회수 필드
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
+
+    //엔티티 저장 전 기본값 보장
+    //Builder 사용 시 null이 될 수 있는 필드(createdAt, updatedAt, viewCount)를
+    //NOT NULL 제약 위반 없이 안전하게 초기화하기 위한 생명주기 콜백
+
+    @PrePersist
+    protected void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (this.createdAt == null) {
+            this.createdAt = now;
+        }
+        if (this.updatedAt == null) {
+            this.updatedAt = now;
+        }
+        if (this.viewCount == null) {
+            this.viewCount = 0L;
+        }
+    }
+
     //질문 생성
     public static Question create(User user, String title, String content) {
         LocalDateTime now = LocalDateTime.now();
@@ -67,5 +91,9 @@ public class Question {
         } this.updatedAt = LocalDateTime.now();
     }
 
+    //조회수 증가 로직
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
 
 }

--- a/src/main/java/org/example/playground/domain/question/entity/Question.java
+++ b/src/main/java/org/example/playground/domain/question/entity/Question.java
@@ -48,6 +48,8 @@ public class Question {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
+    //신고횟수, 관리자가 판단할때의 근거
+    private int reportCount = 0;
 
     //엔티티 저장 전 기본값 보장
     //Builder 사용 시 null이 될 수 있는 필드(createdAt, updatedAt, viewCount)를
@@ -96,4 +98,8 @@ public class Question {
         this.viewCount++;
     }
 
+    //질문 신고 횟수 증가
+    public void reportBy(Long reporterId) {
+        this.reportCount++;
+    }
 }

--- a/src/main/java/org/example/playground/domain/question/entity/Question.java
+++ b/src/main/java/org/example/playground/domain/question/entity/Question.java
@@ -51,10 +51,13 @@ public class Question {
     //신고횟수, 관리자가 판단할때의 근거
     private int reportCount = 0;
 
+    // 채택된 답변 id (없으면 null)
+    @Column(name = "acceptedAnswerId")
+    private Long acceptedAnswerId;
+
     //엔티티 저장 전 기본값 보장
     //Builder 사용 시 null이 될 수 있는 필드(createdAt, updatedAt, viewCount)를
     //NOT NULL 제약 위반 없이 안전하게 초기화하기 위한 생명주기 콜백
-
     @PrePersist
     protected void prePersist() {
         LocalDateTime now = LocalDateTime.now();
@@ -102,4 +105,24 @@ public class Question {
     public void reportBy(Long reporterId) {
         this.reportCount++;
     }
+
+    public void acceptAnswer(Long answerId, Long requesterId, Long answerWriterId) {
+        //질문 작성자만
+        if (!this.user.getId().equals(requesterId)) {
+            throw new RuntimeException("질문 작성자만 채택할 수 있습니다.");
+        }
+
+        //한 질문당 1개
+        if (this.acceptedAnswerId != null) {
+            throw new RuntimeException("이미 채택된 답변이 있습니다.");
+        }
+
+        //자기 답변 채택 금지
+        if (requesterId.equals(answerWriterId)) {
+            throw new RuntimeException("자기 답변은 채택할 수 없습니다.");
+        }
+
+        this.acceptedAnswerId = answerId;
+    }
+
 }

--- a/src/main/java/org/example/playground/domain/question/exception/AnswerAcceptForbiddenException.java
+++ b/src/main/java/org/example/playground/domain/question/exception/AnswerAcceptForbiddenException.java
@@ -1,0 +1,7 @@
+package org.example.playground.domain.question.exception;
+
+public class AnswerAcceptForbiddenException extends RuntimeException {
+    public AnswerAcceptForbiddenException() {
+        super("질문 작성자만 답변을 채택할 수 있습니다.");
+    }
+}

--- a/src/main/java/org/example/playground/domain/question/exception/AnswerAlreadyAcceptedException.java
+++ b/src/main/java/org/example/playground/domain/question/exception/AnswerAlreadyAcceptedException.java
@@ -1,0 +1,7 @@
+package org.example.playground.domain.question.exception;
+
+public class AnswerAlreadyAcceptedException extends RuntimeException {
+    public AnswerAlreadyAcceptedException() {
+        super("이미 채택된 답변이 존재합니다.");
+    }
+}

--- a/src/main/java/org/example/playground/domain/question/exception/SelfAnswerAdoptNotAllowedException.java
+++ b/src/main/java/org/example/playground/domain/question/exception/SelfAnswerAdoptNotAllowedException.java
@@ -1,0 +1,7 @@
+package org.example.playground.domain.question.exception;
+
+public class SelfAnswerAdoptNotAllowedException extends RuntimeException {
+    public SelfAnswerAdoptNotAllowedException() {
+        super("자기 답변은 채택할 수 없습니다.");
+    }
+}

--- a/src/main/java/org/example/playground/domain/question/service/QuestionService.java
+++ b/src/main/java/org/example/playground/domain/question/service/QuestionService.java
@@ -1,6 +1,9 @@
 package org.example.playground.domain.question.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.playground.domain.notification.dto.NotificationRequestDTO;
+import org.example.playground.domain.notification.entity.NotificationType;
+import org.example.playground.domain.notification.service.NotificationService;
 import org.example.playground.domain.question.dto.request.QuestionUpdateRequestDTO;
 import org.example.playground.domain.question.dto.response.QuestionDetailResponseDTO;
 import org.example.playground.domain.question.dto.response.QuestionSummaryResponseDTO;
@@ -22,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class QuestionService {
     private final QuestionRepository questionRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     //질문 생성
     @Transactional
@@ -127,6 +131,29 @@ public class QuestionService {
             //프로젝트 공통 예외로?
             throw new RuntimeException("작성자만 가능합니다.");
         }
+    }
+
+    //질문 신고
+    @Transactional
+    public void report(Long questionId, Long reporterId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+        //신고 처리 (도메인 상태 변경)
+        //reportBy() : 질문이 신고된 횟수를 기록한 메서드
+        question.reportBy(reporterId);
+        //TODO 신고 정책/중복신고/횟수 누적 등은 나중에
+
+        Long adminId = 1L; //임시 관리자 계정 ID (팀에서 확정 필요)
+
+        // 알림 전송 (현재 NotificationService는 REPORT_RECEIVED만 지원)
+        NotificationRequestDTO req = new NotificationRequestDTO(
+                adminId,
+                reporterId,
+                NotificationType.REPORT_RECEIVED,
+                "질문 신고가 접수되었습니다. questionId=" + questionId
+        );
+        notificationService.createNotification(req);
     }
 
 }

--- a/src/main/java/org/example/playground/domain/question/service/QuestionService.java
+++ b/src/main/java/org/example/playground/domain/question/service/QuestionService.java
@@ -1,6 +1,8 @@
 package org.example.playground.domain.question.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.playground.domain.answer.entity.Answer;
+import org.example.playground.domain.answer.repository.AnswerRepository;
 import org.example.playground.domain.notification.dto.NotificationRequestDTO;
 import org.example.playground.domain.notification.entity.NotificationType;
 import org.example.playground.domain.notification.service.NotificationService;
@@ -26,6 +28,7 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final AnswerRepository answerRepository;
 
     //질문 생성
     @Transactional
@@ -155,5 +158,24 @@ public class QuestionService {
         );
         notificationService.createNotification(req);
     }
+
+    @Transactional
+    public void acceptAnswer(Long questionId, Long answerId, Long requesterId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RuntimeException("질문 없음"));
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new RuntimeException("답변 없음"));
+
+        // 채택 대상 답변은 그 질문에 달린 답변이어야 함
+        if (!answer.getQuestion().getId().equals(question.getId())) {
+            throw new RuntimeException("해당 질문의 답변만 채택할 수 있습니다.");
+        }
+
+        Long answerWriterId = answer.getUser().getId(); // Answer에 user 있어야 함
+
+        question.acceptAnswer(answer.getId(), requesterId, answerWriterId);
+    }
+
 
 }

--- a/src/main/java/org/example/playground/domain/question/service/QuestionService.java
+++ b/src/main/java/org/example/playground/domain/question/service/QuestionService.java
@@ -87,10 +87,13 @@ public class QuestionService {
 
 
     //질문 1건 상세 조회
-    @Transactional(readOnly = true)
+    @Transactional
     public QuestionDetailResponseDTO findOne(Long id) {
         Question question = questionRepository.findById(id)
                 .orElseThrow(() -> new QuestionNotFoundException(id));
+        //조회수 증가++, 조회수는 변경된느 작업이므로 (readOnly = true) 사용 X
+        question.increaseViewCount();
+
         return QuestionDetailResponseDTO.from(question);
     }
 

--- a/src/main/java/org/example/playground/domain/question/service/QuestionService.java
+++ b/src/main/java/org/example/playground/domain/question/service/QuestionService.java
@@ -2,6 +2,8 @@ package org.example.playground.domain.question.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.playground.domain.answer.entity.Answer;
+import org.example.playground.domain.answer.exception.AnswerNotFoundException;
+import org.example.playground.domain.answer.exception.AnswerNotInQuestionException;
 import org.example.playground.domain.answer.repository.AnswerRepository;
 import org.example.playground.domain.notification.dto.NotificationRequestDTO;
 import org.example.playground.domain.notification.entity.NotificationType;
@@ -9,7 +11,10 @@ import org.example.playground.domain.notification.service.NotificationService;
 import org.example.playground.domain.question.dto.request.QuestionUpdateRequestDTO;
 import org.example.playground.domain.question.dto.response.QuestionDetailResponseDTO;
 import org.example.playground.domain.question.dto.response.QuestionSummaryResponseDTO;
+import org.example.playground.domain.question.exception.AnswerAcceptForbiddenException;
+import org.example.playground.domain.question.exception.AnswerAlreadyAcceptedException;
 import org.example.playground.domain.question.exception.QuestionNotFoundException;
+import org.example.playground.domain.question.exception.SelfAnswerAdoptNotAllowedException;
 import org.example.playground.domain.user.entity.User;
 import org.example.playground.domain.user.exception.UserNotFoundException;
 import org.example.playground.domain.user.repository.UserRepository;
@@ -21,6 +26,9 @@ import org.example.playground.domain.question.dto.request.QuestionCreateRequestD
 import org.example.playground.domain.question.entity.Question;
 import org.example.playground.domain.question.repository.QuestionRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -98,10 +106,13 @@ public class QuestionService {
     public QuestionDetailResponseDTO findOne(Long id) {
         Question question = questionRepository.findById(id)
                 .orElseThrow(() -> new QuestionNotFoundException(id));
-        //조회수 증가++, 조회수는 변경된느 작업이므로 (readOnly = true) 사용 X
+
+        //조회수 증가++, 조회수는 변경되는작업이므로 (readOnly = true) 사용 X
         question.increaseViewCount();
 
-        return QuestionDetailResponseDTO.from(question);
+        List<Answer> answers = answerRepository.findByQuestion_IdOrderByAcceptedDescCreatedAtDesc(id);
+        return QuestionDetailResponseDTO.from(question, answers);
+
     }
 
     //질문 수정
@@ -159,23 +170,49 @@ public class QuestionService {
         notificationService.createNotification(req);
     }
 
+    //답변 채택
     @Transactional
-    public void acceptAnswer(Long questionId, Long answerId, Long requesterId) {
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new RuntimeException("질문 없음"));
+    public void acceptAnswer(Long questionId, Long answerId, Long userId) {
 
-        Answer answer = answerRepository.findById(answerId)
-                .orElseThrow(() -> new RuntimeException("답변 없음"));
+        // 1) 답변 존재 확인 (없으면 404 계열)
+        Answer target = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
 
-        // 채택 대상 답변은 그 질문에 달린 답변이어야 함
-        if (!answer.getQuestion().getId().equals(question.getId())) {
-            throw new RuntimeException("해당 질문의 답변만 채택할 수 있습니다.");
+        // 2) 답변이 해당 질문 소속인지 검증 (URL 조작 방지)
+        if (!target.getQuestion().getId().equals(questionId)) {
+            throw new AnswerNotInQuestionException();
         }
 
-        Long answerWriterId = answer.getUser().getId(); // Answer에 user 있어야 함
+        // 3) 질문 존재 확인 (answer가 question을 들고있긴 하지만, 명시적으로 확인)
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
-        question.acceptAnswer(answer.getId(), requesterId, answerWriterId);
+        // 4) 권한: 질문 작성자만 가능
+        if (!question.getUser().getId().equals(userId)) {
+            throw new AnswerAcceptForbiddenException();
+        }
+
+        // 5) 자기 답변 채택 금지
+        if (target.getUser().getId().equals(userId)) {
+            throw new SelfAnswerAdoptNotAllowedException();
+        }
+
+        //이미 내가 채택한 답변이면 그냥 성공 처리(원하면)
+        if (target.isAccepted()) {
+            return;
+        }
+
+        // 6) 중복 채택 방지 (취소/변경 불가 정책)
+        if (answerRepository.existsByQuestion_IdAndAcceptedTrue(questionId)) {
+            throw new AnswerAlreadyAcceptedException();
+        }
+
+        // 7) 채택 확정
+        target.accept();
     }
+
+
+
 
 
 }


### PR DESCRIPTION
## 질문 상세 조회 시 조회수 증가 기능 추가
- 질문 상세 조회 API(/questions/{id}) 호출 시 조회수(viewCount)가 1 증가하도록 구현
- 목록 조회/검색 API에서는 조회수가 증가하지 않도록 분리
- 엔티티 @PrePersist를 통해 조회수 기본값 0 보장

## 답변 채택 정책 확정 (회의 결정 반영)
- 답변 채택은 1회만 가능, 취소/변경 불가
- 이에 따라: Answer 엔티티의 unaccept() 메서드 제거
- 답변 채택 API를 QuestionController로 단일화
- PATCH /questions/{questionId}/answers/{answerId}/accept
- 중복 라우팅 이슈(Question/AnswerController 동시 accept 매핑) 해결

## 답변 목록 조회 정렬 정책 반영
- 특정 질문의 답변 목록 조회 시:
- 채택된 답변 우선
- 이후 최신순(createdAt DESC)


## 회의 안건
- 현재: 도메인 예외 발생 시 /error 엔드포인트로 넘어가 시큐리티 설정에 따라 401 Unauthorized로 응답이 왜곡되는 현상 존재
- 비즈니스 로직 자체는 정상 동작함을 로그/테스트로 확인

1. @RestControllerAdvice를 통한 전역 예외 처리 도입 여부

2. 도메인 예외별 HTTP 상태코드(400/403/409 등) 정책 통일

3. /error 엔드포인트 permitAll 처리 여부

예외 응답 구조는 수정하지 않았습니다.!

