### PR TITLE
feat : 신고 처리용 질문/답변 서비스 메서드 추가

### DIFF
--- a/src/main/java/org/example/playground/domain/answer/entity/Answer.java
+++ b/src/main/java/org/example/playground/domain/answer/entity/Answer.java
@@ -43,6 +43,10 @@ public class Answer {
     @Column(nullable = false)
     private boolean accepted;
 
+    //삭제여부
+    @Column(nullable = false)
+    private boolean deleted;
+
     // 답변 생성
     public static Answer create(Question question, User user, String content) {
         LocalDateTime now = LocalDateTime.now();
@@ -52,6 +56,8 @@ public class Answer {
                 .content(content)
                 .createdAt(now)
                 .updatedAt(now)
+                .accepted(false)
+                .deleted(false)
                 .build();
     }
 
@@ -68,7 +74,15 @@ public class Answer {
         this.accepted = true;
     }
 
-    
+    //소프트삭제
+    public void softDeleteByAdmin() {
+        this.deleted = true;
+        this.content = "관리자에 의해 삭제된 답변입니다.";
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+
 
 }
 

--- a/src/main/java/org/example/playground/domain/answer/service/AnswerService.java
+++ b/src/main/java/org/example/playground/domain/answer/service/AnswerService.java
@@ -107,6 +107,24 @@ public class AnswerService {
         return AnswerDetailResponseDTO.from(answer);
     }
 
+    //답변 존재 여부만 확인
+    @Transactional(readOnly = true)
+    public void validateAnswerExists(Long answerId) {
+        if (!answerRepository.existsById(answerId)) {
+            throw new AnswerNotFoundException(answerId);
+        }
+    }
+
+    //관리자에 의해 답변삭제 (soft)
+    @Transactional
+    public void softDeleteAnswerByAdmin(Long answerId) {
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+        answer.softDeleteByAdmin();
+    }
+
+
     // ===================== private helpers =====================
 
     // 답변 작성자인지 검증

--- a/src/main/java/org/example/playground/domain/question/service/QuestionService.java
+++ b/src/main/java/org/example/playground/domain/question/service/QuestionService.java
@@ -147,6 +147,25 @@ public class QuestionService {
         }
     }
 
+    //질문 존재 여부만 확인
+    @Transactional(readOnly = true)
+    public void validateQuestionExists(Long questionId) {
+        if (!questionRepository.existsById(questionId)) {
+            throw new QuestionNotFoundException(questionId);
+        }
+    }
+
+    //관리자에 의해 질문 삭제(hard)
+    @Transactional
+    public void deleteQuestionByAdmin(Long questionId) {
+        // 존재 확인(또는 findOrThrow로 엔티티 가져오기)
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+        questionRepository.delete(question);
+    }
+
+
     //질문 신고
     @Transactional
     public void report(Long questionId, Long reporterId) {
@@ -156,9 +175,8 @@ public class QuestionService {
         //신고 처리 (도메인 상태 변경)
         //reportBy() : 질문이 신고된 횟수를 기록한 메서드
         question.reportBy(reporterId);
-        //TODO 신고 정책/중복신고/횟수 누적 등은 나중에
 
-        Long adminId = 1L; //임시 관리자 계정 ID (팀에서 확정 필요)
+        Long adminId = 1L; //임시 관리자 계정 ID, 어떻게 받아와야하지?
 
         // 알림 전송 (현재 NotificationService는 REPORT_RECEIVED만 지원)
         NotificationRequestDTO req = new NotificationRequestDTO(


### PR DESCRIPTION
## 작업 내용
- 신고 처리 시 사용될 질문/답변 관련 서비스 메서드를 추가했습니다.
- 신고 도메인에서 Repository를 직접 접근하지 않도록 했습니다.

### 상세 변경 사항
- QuestionService
  - 신고(관리자) 처리용 질문 하드 삭제 메서드 추가
  - 질문 삭제 시 기존 매핑(cascade REMOVE)에 따라 답변도 함께 삭제됨
- AnswerService
  - 신고(관리자) 처리용 답변 소프트 삭제 메서드 추가
- Answer 엔티티
  - 삭제 상태(`deleted`) 필드 명확화
  - 관리자 삭제 시 내용 변경 및 수정 시간 갱신 로직 추가
 
- 질문/답변 존재 여부 검증을 위한 서비스 메서드 추가

